### PR TITLE
画像を crop してみかんの情報密度を多く

### DIFF
--- a/cnn.py
+++ b/cnn.py
@@ -25,7 +25,9 @@ for label in os.listdir(data_path):
       label_list.append("1")
 
     image_path = dir + "/" + filename
-    image = np.array(Image.open(image_path).resize((244,244)))
+    width, height = 1280, 960
+    crop_args = (240, 80, width - 240, height - 80)
+    image = np.array(Image.open(image_path).crop(crop_args).resize((244,244)))
     image_list.append(image)
 
 image_list = np.array(image_list)


### PR DESCRIPTION
@yasuno0327 CNN の層の定義ありがとう。

とりあえず、画像の縮尺を 244, 244 に合わせるために crop しました。

ところでこの `resize((244,244)` としてる箇所の 244 はどういう意図でこの数値とかあったりしたら教えてくれると嬉しい。
